### PR TITLE
feat: Support Yarn Berry

### DIFF
--- a/.github/workflows/node-pr.yml
+++ b/.github/workflows/node-pr.yml
@@ -7,6 +7,10 @@ on:
         description: "Node package manager to use"
         default: yarn
         type: string
+      is-yarn-berry:
+        description: "If Yarn Berry should be used"
+        default: false
+        type: boolean
       build-command:
         description: "Command to override the build command"
         default: build
@@ -39,6 +43,10 @@ on:
         description: "If the format step should skipped"
         default: false
         type: boolean
+      skip-cache:
+        description: "If the cache should be skipped when installing dependencies"
+        default: false
+        type: boolean
       debug:
         description: "If debug flags should be set"
         default: false
@@ -57,11 +65,15 @@ jobs:
 
       - name: Install dependencies
         run: |
+          debug=${{ inputs.debug && '--verbose' || '' }}
           if [ "${{ inputs.package-manager }}" = "yarn" ]; then
+            lock_dependencies=${{ inputs.is-yarn-berry && '--immutable' || '--frozen-lockfile' }}
+            skip-cache=${{ inputs.skip-cache && '--force' || '' }}
+
             yarn config get nodeLinker
-            yarn install --frozen-lockfile --force ${{ inputs.debug && '--verbose' || '' }}
+            yarn install $lock_dependencies $skip_cache $debug
           else
-            npm ci ${{ inputs.debug && '--verbose' || '' }}
+            npm ci $debug
           fi
 
       # Use tar to store cache so file permissions are maintained (https://github.com/actions/upload-artifact/issues/38)

--- a/.github/workflows/node-pr.yml
+++ b/.github/workflows/node-pr.yml
@@ -7,8 +7,8 @@ on:
         description: "Node package manager to use"
         default: yarn
         type: string
-      is-yarn-berry:
-        description: "If Yarn Berry should be used"
+      is-yarn-classic:
+        description: "If Yarn (pre-Berry) should be used"
         default: false
         type: boolean
       build-command:
@@ -67,7 +67,7 @@ jobs:
         run: |
           debug=${{ inputs.debug && '--verbose' || '' }}
           if [ "${{ inputs.package-manager }}" = "yarn" ]; then
-            lock_dependencies=${{ inputs.is-yarn-berry && '--immutable' || '--frozen-lockfile' }}
+            lock_dependencies=${{ inputs.is-yarn-classic && '--frozen-lockfile' || '--immutable' }}
             skip-cache=${{ inputs.skip-cache && '--force' || '' }}
 
             yarn config get nodeLinker

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of GitHub action workflows. Built using the [reusable workflows](ht
 | Name          | Required | Type    | Default            | Description                        |
 |---------------|----------|---------|--------------------|------------------------------------|
 | package-manager | ❌      | string   | yarn             | Node package manager to use       |
-| is-yarn-berry   | ❌      | boolean  | false            | When `package-manager` is `yarn`, this can be used to indicate that the version of Yarn is v2 (Berry), which changes what flags we can pass to the command       |
+| is-yarn-classic   | ❌      | boolean  | false            | When `package-manager` is `yarn`, this can be used to indicate that the project uses a pre-Berry version of Yarn, which changes what flags we can pass to the command       |
 | skip-cache      | ❌      | boolean  | false            | When `package-manager` is `yarn`, this can be used to indicate that we should use the `--force` flag to tell Yarn to ignore cache and fetch dependencies from the package repository       |
 | build-command   | ❌      | string   | build            | Command to override the build command |
 | test-command    | ❌      | string   | test             | Command to override the test command |

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ A collection of GitHub action workflows. Built using the [reusable workflows](ht
 #### **Inputs**
 | Name          | Required | Type    | Default            | Description                        |
 |---------------|----------|---------|--------------------|------------------------------------|
-| package-manager | ❌      | string  | yarn               | Node package manager to use       |
-| build-command   | ❌      | string  | build              | Command to override the build command |
-| test-command    | ❌      | string  | test               | Command to override the test command |
-| lint-command    | ❌      | string  | lint               | Command to override the lint command |
-| format-command  | ❌      | string  | format             | Command to override the format command |
-| skip-build      | ❌      | boolean | false              | If the build step should be skipped |
-| skip-test       | ❌      | boolean | false              | If the test step should be skipped |
-| skip-lint       | ❌      | boolean | false              | If the lint step should be skipped |
-| skip-format     | ❌      | boolean | false              | If the format step should be skipped |
-| debug           | ❌      | boolean | false              | If debug flags should be set |
+| package-manager | ❌      | string   | yarn             | Node package manager to use       |
+| is-yarn-berry   | ❌      | boolean  | false            | When `package-manager` is `yarn`, this can be used to indicate that the version of Yarn is v2 (Berry), which changes what flags we can pass to the command       |
+| skip-cache      | ❌      | boolean  | false            | When `package-manager` is `yarn`, this can be used to indicate that we should use the `--force` flag to tell Yarn to ignore cache and fetch dependencies from the package repository       |
+| build-command   | ❌      | string   | build            | Command to override the build command |
+| test-command    | ❌      | string   | test             | Command to override the test command |
+| lint-command    | ❌      | string   | lint             | Command to override the lint command |
+| format-command  | ❌      | string   | format           | Command to override the format command |
+| skip-build      | ❌      | boolean  | false            | If the build step should be skipped |
+| skip-test       | ❌      | boolean  | false            | If the test step should be skipped |
+| skip-lint       | ❌      | boolean  | false            | If the lint step should be skipped |
+| skip-format     | ❌      | boolean  | false            | If the format step should be skipped |
+| debug           | ❌      | boolean  | false            | If debug flags should be set |
 
 #### Example Usage
 


### PR DESCRIPTION
This commit introduces 2 new inputs to the Node PR workflow:
- `is-yarn-classic`: flags that we should assume Yarn Classic is being used
  - Checking this against the `package.json` is significantly error-prone, so having the CI control this as an input makes this decision more explicit
  - The change that this makes is it uses the `--frozen-lockfile` flag instead of `--immutable`
- `skip-cache`: flags that we should use `--force` when installing dependencies to skip the cache and install from the package repository