### PR TITLE
feat: fetch origin so that we have refs

### DIFF
--- a/.github/workflows/node-pr.yml
+++ b/.github/workflows/node-pr.yml
@@ -120,6 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch Origin
+        run: git fetch origin
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
@@ -140,6 +142,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch Origin
+        run: git fetch origin
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
@@ -160,6 +164,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch Origin
+        run: git fetch origin
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
@@ -180,6 +186,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch Origin
+        run: git fetch origin
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
Specifically so that if we are part of an NX monorepo, we can do an `nx affected` and have it point at `origin/<branch>` as the comparison branch