### PR TITLE
feat + fix:  add nx serverless environment

### DIFF
--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -1,11 +1,6 @@
 name: 🚀 Deploy
 
 on:
-  push:
-    branches:
-      - production
-      - staging
-      - development
   workflow_call:
     inputs:
       aws-access-key-id:

--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -24,6 +24,10 @@ on:
         description: "Stage to deploy to"
         type: string
         required: true
+      environment:
+        description: "The GitHub environment to run the workflow in"
+        type: string
+        required: true
       command:
         description: "Command to run"
         type: string
@@ -58,6 +62,7 @@ jobs:
   deploy:
     needs: build-and-install
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: 🚧 Configure Serverless
         run: |

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ jobs:
 ### Nx Serverless Deployment
 
 #### **Inputs**
-| Name                  | Required | Type    | Default         | Description                                |
-|--------------------- |----------|---------|-----------------|-------------------------------------------|
+| Name                  | Required | Type    | Default         | Description                               |
+|--------------------- |----------|---------|-----------------|--------------------------------------------|
 | aws-access-key-id    | ✅       | string  |                 | AWS Access Key                             |
 | aws-secret-access-key| ✅       | string  |                 | AWS Secret Access Key                      |
 | aws-profile          | ✅       | string  |                 | AWS Profile                                |
 | aws-region           | ❌       | string  | ap-southeast-2  | AWS Region to deploy to                    |
 | stage                | ✅       | string  |                 | Stage to deploy to                         |
+| environment          | ✅       | string  |                 | The GitHub environment to run in           |
 | command              | ❌       | string  | build           | Command to run during the deploy step      |
 | package-manager      | ❌       | string  | yarn            | Node package manager to use                |
 | build-command        | ❌       | string  | build           | Command to override the build command      |
@@ -57,6 +58,7 @@ jobs:
       aws-access-key-id: 123
       aws-secret-access-key: 456
       aws-profile: my-profile
-      stage: development
+      stage: dev
+      environment: development
       debug: true
 ```


### PR DESCRIPTION
Since this is a shared workflow, we need to accept the `environment` rather than this being defined on the parent workflow.