### PR TITLE
fix: move secrets values from inputs to secrets

### DIFF
--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -8,14 +8,6 @@ on:
       - development
   workflow_call:
     inputs:
-      aws-access-key-id:
-        description: "AWS access key"
-        type: string
-        required: true
-      aws-secret-access-key:
-        description: "AWS secret access key"
-        type: string
-        required: true
       aws-profile:
         description: "AWS profile"
         type: string
@@ -49,6 +41,13 @@ on:
         type: boolean
         required: false
         default: false
+    secrets:
+      aws-access-key-id:
+        description: "AWS access key"
+        required: true
+      aws-secret-access-key:
+        description: "AWS secret access key"
+        required: true
 
 jobs:
   build-and-install:
@@ -74,8 +73,8 @@ jobs:
             --profile ${{ env.AWS_PROFILE }}\
             ${{ env.DEBUG == 'true' && ' --verbose' || '' }}
         env:
-          AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws-secret-access-key }}
           AWS_PROFILE: ${{ inputs.aws-profile }}
           AWS_REGION: ${{ inputs.aws-region }}
           DEBUG: ${{ inputs.debug }}

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ jobs:
   deploy-serverless:
     uses: aligent/workflows/.github/workflows/nx-serverless-deployment.yml@main
     with:
-      aws-access-key-id: 123
-      aws-secret-access-key: 456
       aws-profile: my-profile
       stage: development
       debug: true
+    secrets:
+      aws-access-key-id: '123'
+      aws-secret-access-key: '456'
 ```


### PR DESCRIPTION
This means they won't be visible in outputs (so we'll need to check them from the configuration screen - excellent!) and when workflows use this, they'll need to pass them as `secrets` instead of `with`.