### PR TITLE
fix  PJH-43: remove verbose from yarn berry

### DIFF
--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -64,6 +64,7 @@ jobs:
           debug=${{ inputs.debug && '--verbose' || '' }}
           if [ "${{ inputs.package-manager }}" = "yarn" ]; then
             lock_dependencies=${{ inputs.is-yarn-classic && '--frozen-lockfile' || '--immutable' }}
+            debug=${{ (inputs.debug && inputs.is-yarn-classic) && '--verbose' || '' }}
 
             yarn config get nodeLinker
             yarn install $lock_dependencies $skip_cache $debug


### PR DESCRIPTION
Yarn berry doesn't have a `verbose` option. So only add a verbose if we're using yarn classic.