### PR TITLE
fix PJH-43: remove verbose on yarn berry

### DIFF
--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -69,6 +69,8 @@ jobs:
           lock_dependencies="--immutable"
           if [ "${{ inputs.is-yarn-classic }}" = "true" ]; then
             lock_dependencies="--frozen-lockfile"
+          elif [ "${{ inputs.package-manager }}" = "yarn" ]; then
+            debug=""
           fi
 
           if [ "${{ inputs.package-manager }}" = "yarn" ]; then


### PR DESCRIPTION
If it uses the yarn berry package manager ensure we remove the verbose flag.