### PR TITLE
fix PJH-43: fall to use workflow var

### DIFF
--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -112,6 +112,10 @@ jobs:
 
       - name: 🚀 Deploy
         run: |
+          if [ -z "${STAGE}" ]; then
+            STAGE=${{ vars.STAGE }} # Fall back to stage var
+          fi
+
           echo "Deploying to ${STAGE}"
 
           verbose=""


### PR DESCRIPTION
Fall back to use environment variable if the input passed is blank or null.