### PR TITLE
Change Magento auth method to use native environment variable for api authentication

### DIFF
--- a/.github/workflows/magento-cloud-deploy.yml
+++ b/.github/workflows/magento-cloud-deploy.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Configure Magento Cloud CLI authentication
         run: |
           echo "🔐 Configuring Magento Cloud authentication..."
-          magento-cloud auth:login --token "${{ secrets.magento-cloud-cli-token }}"
+          export MAGENTO_CLOUD_CLI_TOKEN="${{ secrets.magento-cloud-cli-token }}"
           echo "✅ Authentication configured"
 
 


### PR DESCRIPTION
This PR should hopefully fix a failed Magento authentication in the pipeline runner when using workflow magento-cloud-deploy.yml