### PR TITLE
Set secret vars at the job level to cover all steps under deploy job

### DIFF
--- a/.github/workflows/magento-cloud-deploy.yml
+++ b/.github/workflows/magento-cloud-deploy.yml
@@ -86,6 +86,8 @@ jobs:
     needs: [validate, newrelic-start]
     if: always() && needs.validate.result == 'success'
     environment: ${{ inputs.environment }}
+    env:
+      MAGENTO_CLOUD_CLI_TOKEN: ${{ secrets.magento-cloud-cli-token }}
     outputs:
       deployment-url: ${{ steps.deploy-info.outputs.url }}
       deployment-id: ${{ steps.deploy-info.outputs.id }}
@@ -105,13 +107,6 @@ jobs:
           # Verify installation
           magento-cloud --version
           echo "✅ Magento Cloud CLI installed successfully"
-
-      - name: Configure Magento Cloud CLI authentication
-        run: |
-          echo "🔐 Configuring Magento Cloud authentication..."
-          export MAGENTO_CLOUD_CLI_TOKEN="${{ secrets.magento-cloud-cli-token }}"
-          echo "✅ Authentication configured"
-
 
       - name: Deploy to Magento Cloud
         id: deployment


### PR DESCRIPTION
Second attempt to fix up the magento authentication inside runners. 
This PR sets the secret variables at the job level, which covers all steps within that deploy job.
The problem I was having was that each step is a new fresh container and so it looses it's credentials on each new step thereafter.