### PR TITLE
Fix issue with the inputs including || in the value

### DIFF
--- a/.github/workflows/pwa-deployment.yml
+++ b/.github/workflows/pwa-deployment.yml
@@ -124,8 +124,8 @@ jobs:
         id: validate-inputs
         env:
           ENVIRONMENT: ${{ inputs.environment }}
-          S3_BUCKET: ${{ vars.S3_BUCKET }} || ${{ inputs.s3-bucket }}
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} || ${{ inputs.cloudfront-distribution-id }}
+          S3_BUCKET: ${{ vars.S3_BUCKET || inputs.s3-bucket }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID || inputs.cloudfront-distribution-id }}
           VAR_AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
           SECRET_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           VAR_AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
@@ -261,7 +261,7 @@ jobs:
           fi
         env:
           INPUTS_PREVIEW_BASE_URL: ${{ inputs.preview-base-url }}
-          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET }} || ${{ inputs.s3-bucket }}
+          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET || inputs.s3-bucket }}
 
       - name: Configure multi-brand matrix
         id: brand-config
@@ -395,7 +395,7 @@ jobs:
         env:
           NEEDS_PREPARE_OUTPUTS_S3_PREFIX: ${{ needs.prepare.outputs.s3-prefix }}
           MATRIX_BRAND: ${{ matrix.brand }}
-          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET }} || ${{ inputs.s3-bucket }}
+          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET || inputs.s3-bucket }}
 
       - name: Deploy static assets to S3
         run: |
@@ -412,7 +412,7 @@ jobs:
             ${INPUTS_EXTRA_SYNC_ARGS}
         env:
           INPUTS_BUILD_DIRECTORY: ${{ inputs.build-directory }}
-          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET }} || ${{ inputs.s3-bucket }}
+          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET || inputs.s3-bucket }}
           STEPS_S3_CONFIG_OUTPUTS_S3_PATH: ${{ steps.s3-config.outputs.s3-path }}
           NEEDS_PREPARE_OUTPUTS_CACHE_CONTROL_STATIC: ${{ needs.prepare.outputs.cache-control-static }}
           INPUTS_EXTRA_SYNC_ARGS: ${{ inputs.extra-sync-args }}
@@ -432,7 +432,7 @@ jobs:
             ${INPUTS_EXTRA_SYNC_ARGS}
         env:
           INPUTS_BUILD_DIRECTORY: ${{ inputs.build-directory }}
-          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET }} || ${{ inputs.s3-bucket }}
+          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET || inputs.s3-bucket }}
           STEPS_S3_CONFIG_OUTPUTS_S3_PATH: ${{ steps.s3-config.outputs.s3-path }}
           NEEDS_PREPARE_OUTPUTS_CACHE_CONTROL_HTML: ${{ needs.prepare.outputs.cache-control-html }}
           INPUTS_EXTRA_SYNC_ARGS: ${{ inputs.extra-sync-args }}
@@ -512,7 +512,7 @@ jobs:
         env:
           INPUTS_ENVIRONMENT: ${{ inputs.environment }}
           MATRIX_BRAND: ${{ matrix.brand }}
-          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET }} || ${{ inputs.s3-bucket }}
+          INPUTS_S3_BUCKET: ${{ vars.S3_BUCKET || inputs.s3-bucket }}
           STEPS_S3_CONFIG_OUTPUTS_S3_PATH: ${{ steps.s3-config.outputs.s3-path }}
           INPUTS_CACHE_STRATEGY: ${{ inputs.cache-strategy }}
           NEEDS_PREPARE_OUTPUTS_DEPLOYMENT_URL: ${{ needs.prepare.outputs.deployment-url }}

--- a/.github/workflows/pwa-deployment.yml
+++ b/.github/workflows/pwa-deployment.yml
@@ -485,7 +485,7 @@ jobs:
           NEEDS_PREPARE_OUTPUTS_INVALIDATION_PATHS: ${{ needs.prepare.outputs.invalidation-paths }}
           MATRIX_BRAND: ${{ matrix.brand }}
           STEPS_S3_CONFIG_OUTPUTS_S3_PATH: ${{ steps.s3-config.outputs.s3-path }}
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} || ${{ inputs.cloudfront-distribution-id }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID || inputs.cloudfront-distribution-id }}
           INPUTS_DEBUG: ${{ inputs.debug }}
 
       - name: Generate deployment summary


### PR DESCRIPTION
**Description of the proposed changes**
Input values are including the || in them as it is not evaluated at runtime. I've moved it into the templating functions so it actually gets evaluated and not printed.

Example:
```
Invalid bucket name "pwa-staging.ovarohome.com.au || ": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-.]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
```

REF: https://github.com/aligent/otr-pwa/actions/runs/24171707023/job/70544578503

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

