### PR TITLE
MI-315: Upgrade gadget deployment pipeline

### DIFF
--- a/.github/workflows/gadget-deploy.yml
+++ b/.github/workflows/gadget-deploy.yml
@@ -12,22 +12,18 @@ on:
         type: string
         required: false
         default: "."
-      environment-name: 
-        description: "Staging/Development environment of Gadget App to push code"
+      environment-name:
+        description: "Staging/Development environment of Gadget App to push code (required when action is 'push')"
         type: string
-        default: "staging"
+        required: false
 
       # Deployment Control
-      push-staging:
-        description: "Boolean to check if push to staging/development Gadget environment"
-        type: boolean
-        default: false
+      action:
+        description: "Deployment action to perform: 'push' (push to environment) or 'deploy' (deploy to production)"
+        type: string
+        required: true
       test:
         description: "Boolean to check if run tests"
-        type: boolean
-        default: false    
-      deploy-production:
-        description: "Boolean to check if promot from staging/development to production"
         type: boolean
         default: false
 
@@ -43,12 +39,21 @@ jobs:
   push:
     name: 🫸 Push to Gadget
     runs-on: ubuntu-latest
+    if: inputs.action == 'push'
     env:
       GGT_TOKEN: ${{ secrets.gadget-api-token }}
     outputs:
       push-environment-status: ${{ steps.push-environment.outcome }}
-    if: inputs.push-staging == true
     steps:
+      - name: Validate environment-name
+        run: |
+          if [ -z "${INPUTS_ENVIRONMENT_NAME}" ]; then
+            echo "::error::environment-name is required when action is 'push'"
+            exit 1
+          fi
+        env:
+          INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
@@ -73,10 +78,10 @@ jobs:
   test:
     name: 🧪 Test from Gadget
     runs-on: ubuntu-latest
+    if: inputs.test == true
+    needs: push
     env:
       GGT_TOKEN: ${{ secrets.gadget-api-token }}
-    needs: push
-    if: inputs.test == true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -124,10 +129,11 @@ jobs:
   deploy:
     name: 🚀 Deploying Gadget
     runs-on: ubuntu-latest
+    if: inputs.action == 'deploy'
     env:
       GGT_TOKEN: ${{ secrets.gadget-api-token }}
       INPUTS_APP_NAME: ${{ inputs.app-name }}
-    if: inputs.deploy-production == true
+      TEMP_ENV_NAME: deploy-${{ github.run_id }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -138,46 +144,30 @@ jobs:
           npm install -g ggt
           ggt version
 
-      - name: Sanitize environment name
-        id: sanitize-env
-        run: |
-          SANITIZED=$(echo "${INPUTS_ENVIRONMENT_NAME}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
-          echo "env-name=${SANITIZED}" >> "$GITHUB_OUTPUT"
-        env:
-          INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
-
       - name: Create temp Gadget environment
         run: |
-          ggt env create ${SANITIZED_ENV} \
+          ggt env create ${TEMP_ENV_NAME} \
             --app ${INPUTS_APP_NAME}
-        env:
-          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}
 
       - name: Push code to temp Gadget environment
         working-directory: ${{ inputs.working-directory }}
         run: |
           ggt push \
             --app=${INPUTS_APP_NAME} \
-            --env=${SANITIZED_ENV_NAME} \
+            --env=${TEMP_ENV_NAME} \
             --force --allow-unknown-directory
-        env:
-          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}
 
       - name: Deploy (promote) to Production environment in Gadget
         working-directory: ${{ inputs.working-directory }}
         run: |
           ggt deploy \
             --app=${INPUTS_APP_NAME} \
-            --env=${SANITIZED_ENV_NAME} \
+            --env=${TEMP_ENV_NAME} \
             --force --allow-unknown-directory --allow-problems
-        env:
-          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}
 
       - name: Remove temp Gadget environment
         if: always()
         run: |
-          ggt env delete ${SANITIZED_ENV_NAME} \
+          ggt env delete ${TEMP_ENV_NAME} \
             --app ${INPUTS_APP_NAME} \
             --force
-        env:
-          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}

--- a/.github/workflows/gadget-deploy.yml
+++ b/.github/workflows/gadget-deploy.yml
@@ -78,7 +78,7 @@ jobs:
   test:
     name: 🧪 Test from Gadget
     runs-on: ubuntu-latest
-    if: inputs.test == true
+    if: inputs.test == true && inputs.action == 'push'
     needs: push
     env:
       GGT_TOKEN: ${{ secrets.gadget-api-token }}

--- a/.github/workflows/gadget-deploy.yml
+++ b/.github/workflows/gadget-deploy.yml
@@ -62,7 +62,10 @@ jobs:
         id: push-environment
         working-directory: ${{ inputs.working-directory }}
         run: |
-          ggt push --app=${INPUTS_APP_NAME} --env=${INPUTS_ENVIRONMENT_NAME} --force --allow-unknown-directory
+          ggt push \
+            --app=${INPUTS_APP_NAME} \
+            --env=${INPUTS_ENVIRONMENT_NAME} \
+            --force --allow-unknown-directory
         env:
           INPUTS_APP_NAME: ${{ inputs.app-name }}
           INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }} 
@@ -87,7 +90,10 @@ jobs:
       - name: Pull client files into env # pull .gadget folder into test runner
         working-directory: ${{ inputs.working-directory }}
         run: |
-          ggt pull --app=${INPUTS_APP_NAME} --env=${INPUTS_ENVIRONMENT_NAME} --force --allow-unknown-directory
+          ggt pull \
+            --app=${INPUTS_APP_NAME} \
+            --env=${INPUTS_ENVIRONMENT_NAME} \
+            --force --allow-unknown-directory
         env:
           INPUTS_APP_NAME: ${{ inputs.app-name }}
           INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
@@ -120,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GGT_TOKEN: ${{ secrets.gadget-api-token }}
+      INPUTS_APP_NAME: ${{ inputs.app-name }}
     if: inputs.deploy-production == true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -131,14 +138,46 @@ jobs:
           npm install -g ggt
           ggt version
 
+      - name: Sanitize environment name
+        id: sanitize-env
+        run: |
+          SANITIZED=$(echo "${INPUTS_ENVIRONMENT_NAME}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+          echo "env-name=${SANITIZED}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
+
+      - name: Create temp Gadget environment
+        run: |
+          ggt env create ${SANITIZED_ENV} \
+            --app ${INPUTS_APP_NAME}
+        env:
+          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}
+
+      - name: Push code to temp Gadget environment
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          ggt push \
+            --app=${INPUTS_APP_NAME} \
+            --env=${SANITIZED_ENV_NAME} \
+            --force --allow-unknown-directory
+        env:
+          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}
+
       - name: Deploy (promote) to Production environment in Gadget
         working-directory: ${{ inputs.working-directory }}
         run: |
           ggt deploy \
             --app=${INPUTS_APP_NAME} \
-            --env=${INPUTS_ENVIRONMENT_NAME} \
+            --env=${SANITIZED_ENV_NAME} \
             --force --allow-unknown-directory --allow-problems
-
         env:
-          INPUTS_APP_NAME: ${{ inputs.app-name }}
-          INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
+          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}
+
+      - name: Remove temp Gadget environment
+        if: always()
+        run: |
+          ggt env delete ${SANITIZED_ENV_NAME} \
+            --app ${INPUTS_APP_NAME} \
+            --force
+        env:
+          SANITIZED_ENV_NAME: ${{ steps.sanitize-env.outputs.env-name }}

--- a/docs/gadget-deploy.md
+++ b/docs/gadget-deploy.md
@@ -6,6 +6,7 @@ A comprehensive Gadget app deployment workflow supporting push, test, and produc
 - **Custom-environment support**: Support for custom development environment name
 - **Conditional automated testing**: Automatic test execution controlled by boolean flag
 - **Conditional deployment**: Production deployment controlled by boolean flag
+- **Temporary environment deployment**: Production deploys create a temporary Gadget environment, push code to it, promote to production, and clean up automatically
 - **Force push capabilities**: Ensures code synchronization with `--force` flag
 - **Gadget CLI integration**: Uses `ggt` CLI tool for all operations
 - **Test validation**: Runs full test suite before production deployment
@@ -113,8 +114,18 @@ jobs:
     with:
       app-name: my-gadget-app
       working-directory: apps/gadget-app
-      environment-name: staging
+      environment-name: ${{ github.event.release.tag_name }}
       deploy-production: true
     secrets:
       gadget-api-token: ${{ secrets.GADGET_API_TOKEN }}
 ```
+
+When `deploy-production: true`, the workflow uses a temporary environment strategy to safely promote code to production:
+
+1. **Sanitize** — The `environment-name` is sanitized to meet Gadget's naming requirements (lowercase `a-z`, `0-9`, and dashes only). For example, `v1.2.0` becomes `v1-2-0`.
+2. **Create** — A temporary Gadget environment is created using the sanitized name. This ensures the deployment is isolated from the main development/staging environment.
+3. **Push** — The checked-out code is pushed to this temporary environment using `ggt push`.
+4. **Deploy** — The temporary environment is promoted to production using `ggt deploy`.
+5. **Cleanup** — The temporary environment is deleted after deployment, regardless of success or failure.
+
+This approach avoids deploying uncommitted or unreviewed changes that may exist in the shared staging environment, ensuring only the exact code from the Git ref is promoted to production.

--- a/docs/gadget-deploy.md
+++ b/docs/gadget-deploy.md
@@ -17,11 +17,10 @@ A comprehensive Gadget app deployment workflow supporting push, test, and produc
 | **Core Configuration** |
 | app-name | ✅ | string | | Gadget App name to deploy to |
 | working-directory | ❌ | string | . | Working directory of Gadget App |
-| environment-name | ❌ | string | staging | Main _development_ environment name |
+| environment-name | ⚠️ | string | | Gadget environment name (required when `action: push`) |
 | **Deployment Control** |
-| push-staging | ❌ | boolean | false | Enable production deployment |
+| action | ✅ | string | | Deployment action: `push` (push to environment) or `deploy` (deploy to production) |
 | test | ❌ | boolean | false | Enable testing on development environment |
-| deploy-production | ❌ | boolean | false | Enable production deployment |
 
 #### **Secrets**
 | Name | Required | Description |
@@ -52,7 +51,7 @@ jobs:
       app-name: my-gadget-app
       working-directory: apps/gadget-app
       environment-name: staging
-      push-staging: true
+      action: push
     secrets:
       gadget-api-token: ${{ secrets.GADGET_API_TOKEN }}
 ```
@@ -73,6 +72,7 @@ jobs:
     with:
       app-name: my-gadget-app
       environment-name: development
+      action: push
     secrets:
       gadget-api-token: ${{ secrets.GADGET_API_TOKEN }}
 ```
@@ -93,7 +93,7 @@ jobs:
       app-name: my-gadget-app
       working-directory: apps/gadget-app
       environment-name: staging
-      push-staging: true
+      action: push
       test: true
     secrets:
       gadget-api-token: ${{ secrets.GADGET_API_TOKEN }}
@@ -114,18 +114,16 @@ jobs:
     with:
       app-name: my-gadget-app
       working-directory: apps/gadget-app
-      environment-name: ${{ github.event.release.tag_name }}
-      deploy-production: true
+      action: deploy
     secrets:
       gadget-api-token: ${{ secrets.GADGET_API_TOKEN }}
 ```
 
-When `deploy-production: true`, the workflow uses a temporary environment strategy to safely promote code to production:
+When `action: deploy`, the workflow uses a temporary environment strategy to safely promote code to production:
 
-1. **Sanitize** — The `environment-name` is sanitized to meet Gadget's naming requirements (lowercase `a-z`, `0-9`, and dashes only). For example, `v1.2.0` becomes `v1-2-0`.
-2. **Create** — A temporary Gadget environment is created using the sanitized name. This ensures the deployment is isolated from the main development/staging environment.
-3. **Push** — The checked-out code is pushed to this temporary environment using `ggt push`.
-4. **Deploy** — The temporary environment is promoted to production using `ggt deploy`.
-5. **Cleanup** — The temporary environment is deleted after deployment, regardless of success or failure.
+1. **Create** — A temporary Gadget environment named `deploy-<run_id>` is created (e.g. `deploy-12345678`), using the GitHub Actions run ID for uniqueness. This ensures the deployment is isolated from the main development/staging environment.
+2. **Push** — The checked-out code is pushed to this temporary environment using `ggt push`.
+3. **Deploy** — The temporary environment is promoted to production using `ggt deploy`.
+4. **Cleanup** — The temporary environment is deleted after deployment, regardless of success or failure.
 
 This approach avoids deploying uncommitted or unreviewed changes that may exist in the shared staging environment, ensuring only the exact code from the Git ref is promoted to production.


### PR DESCRIPTION
**Description of the proposed changes**
- Replaced `push-staging` and `deploy-production` boolean inputs with a single action input — callers must now pass `action: push` or `action: deploy` instead of setting separate booleans.
- `environment-name` is no longer defaulted to "staging" — it is now optional overall but required when action: push, with a runtime validation step that fails fast if missing.
- Temporary environment strategy for production deploys — when action: deploy, the workflow automatically:
  - Creates a temporary Gadget environment (deploy-<run_id>)
  - Pushes the checked-out code to it
  - Promotes (deploys) to production
  - Cleans up the temporary environment (runs even on failure)
  This ensures only the exact code from the Git ref is promoted, avoiding unreviewed changes in shared staging.

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

