### PR TITLE
feat: Add automatic backporting to staging for deployment workflows

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -1,0 +1,144 @@
+name: 'Backport Branch'
+description: 'Create a backport PR from one branch to another'
+author: 'Aligent'
+
+inputs:
+  target-branch:
+    description: 'Target branch to backport to'
+    required: false
+    default: 'staging'
+  source-branch:
+    description: 'Source branch to backport from (defaults to current branch)'
+    required: false
+    default: ''
+  title-prefix:
+    description: 'Prefix for PR title'
+    required: false
+    default: 'Backport:'
+
+outputs:
+  pr-url:
+    description: 'URL of the created or existing PR'
+    value: ${{ steps.backport.outputs.pr-url }}
+  status:
+    description: 'Status of the backport: created, exists, up-to-date, or skipped'
+    value: ${{ steps.backport.outputs.status }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Backport
+      id: backport
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        SOURCE_BRANCH: ${{ inputs.source-branch || github.ref_name }}
+        TITLE_PREFIX: ${{ inputs.title-prefix }}
+        REPO: ${{ github.repository }}
+        ACTOR: ${{ github.actor }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+
+        echo "::group::Validating source branch"
+
+        # Only allow backporting from production-like branches
+        ALLOWED_BRANCHES="production main master"
+        if ! echo "$ALLOWED_BRANCHES" | grep -qw "$SOURCE_BRANCH"; then
+          echo "Skipping backport: source branch '${SOURCE_BRANCH}' is not a production branch"
+          echo "Allowed branches: ${ALLOWED_BRANCHES}"
+          echo "status=skipped" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+          exit 0
+        fi
+        echo "Source branch '${SOURCE_BRANCH}' is valid for backporting"
+
+        echo "::endgroup::"
+
+        echo "::group::Validating branches"
+
+        # Check if target branch exists
+        if ! gh api "repos/${REPO}/branches/${TARGET_BRANCH}" --silent 2>/dev/null; then
+          echo "::error::Target branch '${TARGET_BRANCH}' does not exist"
+          exit 1
+        fi
+        echo "Target branch exists: ${TARGET_BRANCH}"
+
+        # Check if source branch exists
+        if ! gh api "repos/${REPO}/branches/${SOURCE_BRANCH}" --silent 2>/dev/null; then
+          echo "::error::Source branch '${SOURCE_BRANCH}' does not exist"
+          exit 1
+        fi
+        echo "Source branch exists: ${SOURCE_BRANCH}"
+
+        echo "::endgroup::"
+
+        echo "::group::Checking for existing PR"
+
+        EXISTING_PR=$(gh pr list --repo "${REPO}" --base "${TARGET_BRANCH}" \
+          --head "${SOURCE_BRANCH}" --json url --jq '.[0].url // empty')
+
+        if [ -n "${EXISTING_PR}" ]; then
+          echo "PR already exists: ${EXISTING_PR}"
+          echo "pr-url=${EXISTING_PR}" >> $GITHUB_OUTPUT
+          echo "status=exists" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+          exit 0
+        fi
+        echo "No existing PR found"
+
+        echo "::endgroup::"
+
+        echo "::group::Checking for changes"
+
+        COMPARE=$(gh api "repos/${REPO}/compare/${TARGET_BRANCH}...${SOURCE_BRANCH}" \
+          --jq '{ahead: .ahead_by, status: .status}')
+        AHEAD_BY=$(echo "${COMPARE}" | jq -r '.ahead')
+
+        if [ "${AHEAD_BY}" -eq 0 ]; then
+          echo "No commits to backport (branches are identical)"
+          echo "status=up-to-date" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+          exit 0
+        fi
+        echo "Found ${AHEAD_BY} commit(s) to backport"
+
+        echo "::endgroup::"
+
+        echo "::group::Creating backport PR"
+
+        PR_TITLE="${TITLE_PREFIX} ${SOURCE_BRANCH} → ${TARGET_BRANCH}"
+        PR_BODY=$(cat <<EOF
+        ## Backport PR
+
+        This PR backports changes from \`${SOURCE_BRANCH}\` to \`${TARGET_BRANCH}\`.
+
+        ### Details
+        - **Source Branch:** \`${SOURCE_BRANCH}\`
+        - **Target Branch:** \`${TARGET_BRANCH}\`
+        - **Commits:** ${AHEAD_BY}
+        - **Triggered by:** @${ACTOR}
+        - **Workflow Run:** ${RUN_URL}
+
+        ### Instructions
+        1. Review the changes
+        2. Resolve any conflicts if present
+        3. Approve and merge when ready
+
+        *This PR was automatically created by the backport action.*
+        EOF
+        )
+
+        PR_URL=$(gh pr create \
+          --repo "${REPO}" \
+          --base "${TARGET_BRANCH}" \
+          --head "${SOURCE_BRANCH}" \
+          --title "${PR_TITLE}" \
+          --body "${PR_BODY}")
+
+        echo "Created PR: ${PR_URL}"
+        echo "pr-url=${PR_URL}" >> $GITHUB_OUTPUT
+        echo "status=created" >> $GITHUB_OUTPUT
+
+        echo "::endgroup::"

--- a/.github/workflows/aio-app-deployment.yml
+++ b/.github/workflows/aio-app-deployment.yml
@@ -105,3 +105,9 @@ jobs:
           AIO_PROJECT_WORKSPACE_NAME: ${{ vars.AIO_PROJECT_WORKSPACE_NAME }}
           VERBOSE: ${{ inputs.debug && '--verbose' || '' }}
         run: aio app deploy${VERBOSE:+ $VERBOSE}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/aio-app-deployment.yml
+++ b/.github/workflows/aio-app-deployment.yml
@@ -30,6 +30,18 @@ on:
         required: false
         default: false
 
+      # Backport Configuration
+      create-backport-pr:
+        description: Create a backport PR to staging after deployment
+        type: boolean
+        required: false
+        default: false
+      backport-target-branch:
+        description: Target branch for backport PR
+        type: string
+        required: false
+        default: staging
+
 jobs:
   deploy:
     name: Deploy AIO App
@@ -107,7 +119,7 @@ jobs:
         run: aio app deploy${VERBOSE:+ $VERBOSE}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/aio-mesh-deployment.yml
+++ b/.github/workflows/aio-mesh-deployment.yml
@@ -45,6 +45,18 @@ on:
         required: false
         default: false
 
+      # Backport Configuration
+      create-backport-pr:
+        description: Create a backport PR to staging after deployment
+        type: boolean
+        required: false
+        default: false
+      backport-target-branch:
+        description: Target branch for backport PR
+        type: string
+        required: false
+        default: staging
+
 jobs:
   deploy:
     name: Deploy API Mesh
@@ -188,7 +200,7 @@ jobs:
         run: aio api-mesh:describe
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/aio-mesh-deployment.yml
+++ b/.github/workflows/aio-mesh-deployment.yml
@@ -186,3 +186,9 @@ jobs:
 
       - name: Describe mesh
         run: aio api-mesh:describe
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/gadget-deploy.yml
+++ b/.github/workflows/gadget-deploy.yml
@@ -31,6 +31,16 @@ on:
         type: boolean
         default: false
 
+      # Backport Configuration
+      create-backport-pr:
+        description: "Create a backport PR to staging after deployment"
+        type: boolean
+        default: false
+      backport-target-branch:
+        description: "Target branch for backport PR"
+        type: string
+        default: "staging"
+
     secrets:
       gadget-api-token:
         description: "Gadget API token"
@@ -144,7 +154,7 @@ jobs:
           INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/gadget-deploy.yml
+++ b/.github/workflows/gadget-deploy.yml
@@ -142,3 +142,9 @@ jobs:
         env:
           INPUTS_APP_NAME: ${{ inputs.app-name }}
           INPUTS_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/magento-cloud-deploy.yml
+++ b/.github/workflows/magento-cloud-deploy.yml
@@ -45,6 +45,18 @@ on:
         required: false
         default: false
 
+      # Backport Configuration
+      create-backport-pr:
+        description: "Create a backport PR to staging after deployment"
+        type: boolean
+        required: false
+        default: false
+      backport-target-branch:
+        description: "Target branch for backport PR"
+        type: string
+        required: false
+        default: "staging"
+
     secrets:
       magento-cloud-cli-token:
         description: "Magento Cloud CLI token for authentication"
@@ -371,7 +383,7 @@ jobs:
           SECRETS_CST_REPORTING_TOKEN: ${{ secrets.CST_REPORTING_TOKEN }}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/magento-cloud-deploy.yml
+++ b/.github/workflows/magento-cloud-deploy.yml
@@ -369,3 +369,9 @@ jobs:
           GITHUB_EVENT_REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           SECRETS_CST_REPORTING_TOKEN_INPUT: ${{ secrets.cst-reporting-token }}
           SECRETS_CST_REPORTING_TOKEN: ${{ secrets.CST_REPORTING_TOKEN }}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -26,6 +26,19 @@ on:
         type: boolean
         required: false
         default: false
+
+      # Backport Configuration
+      create-backport-pr:
+        description: "Create a backport PR to staging after deployment"
+        type: boolean
+        required: false
+        default: false
+      backport-target-branch:
+        description: "Target branch for backport PR"
+        type: string
+        required: false
+        default: "staging"
+
     secrets:
       AWS_SECRET_ACCESS_KEY:
         required: false
@@ -199,7 +212,7 @@ jobs:
           STEPS_REPO_TYPE_OUTPUTS_IS_MONOREPO: ${{ steps.repo-type.outputs.is_monorepo }}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/nx-serverless-deployment.yml
+++ b/.github/workflows/nx-serverless-deployment.yml
@@ -197,3 +197,9 @@ jobs:
           DEBUG: ${{ inputs.debug }}
 
           STEPS_REPO_TYPE_OUTPUTS_IS_MONOREPO: ${{ steps.repo-type.outputs.is_monorepo }}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/pwa-deployment.yml
+++ b/.github/workflows/pwa-deployment.yml
@@ -529,3 +529,9 @@ jobs:
           INPUTS_BUILD_COMMAND: ${{ inputs.build-command }}
           INPUTS_BUILD_DIRECTORY: ${{ inputs.build-directory }}
           INPUTS_PREVIEW_MODE: ${{ inputs.preview-mode }}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/pwa-deployment.yml
+++ b/.github/workflows/pwa-deployment.yml
@@ -96,6 +96,18 @@ on:
         required: false
         default: false
 
+      # Backport Configuration
+      create-backport-pr:
+        description: "Create a backport PR to staging after deployment"
+        type: boolean
+        required: false
+        default: false
+      backport-target-branch:
+        description: "Target branch for backport PR"
+        type: string
+        required: false
+        default: "staging"
+
     outputs:
       deployment-url:
         description: "URL of the deployed application"
@@ -531,7 +543,7 @@ jobs:
           INPUTS_PREVIEW_MODE: ${{ inputs.preview-mode }}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -39,6 +39,19 @@ on:
         description: "AWS Access Key ID"
         type: string
         required: true
+
+      # Backport Configuration
+      create-backport-pr:
+        description: "Create a backport PR to staging after deployment"
+        type: boolean
+        required: false
+        default: false
+      backport-target-branch:
+        description: "Target branch for backport PR"
+        type: string
+        required: false
+        default: "staging"
+
     secrets:
       aws-secret-access-key:
         description: "AWS Secret Access Key"
@@ -86,7 +99,7 @@ jobs:
           INPUTS_DELETE_FLAG: ${{ inputs.delete-flag }}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -84,3 +84,9 @@ jobs:
           INPUTS_S3_PATH: ${{inputs.s3-path}}
           INPUTS_EXTRA_ARGS: ${{inputs.extra-args}}
           INPUTS_DELETE_FLAG: ${{ inputs.delete-flag }}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/shopify-deploy.yml
+++ b/.github/workflows/shopify-deploy.yml
@@ -29,6 +29,16 @@ on:
         type: boolean
         default: false
 
+      # Backport Configuration
+      create-backport-pr:
+        description: "Create a backport PR to staging after deployment"
+        type: boolean
+        default: false
+      backport-target-branch:
+        description: "Target branch for backport PR"
+        type: string
+        default: "staging"
+
     secrets:
       shopify_cli_token:
         description: 'Shopify CLI authentication token'
@@ -88,7 +98,7 @@ jobs:
           SHOPIFY_FLAG_PATH: ${{ inputs.working-directory }}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/.github/workflows/shopify-deploy.yml
+++ b/.github/workflows/shopify-deploy.yml
@@ -86,3 +86,9 @@ jobs:
         env:
           SHOPIFY_CLI_TOKEN: ${{ secrets.shopify_cli_token }}
           SHOPIFY_FLAG_PATH: ${{ inputs.working-directory }}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/static-hosting-deployment.yml
+++ b/.github/workflows/static-hosting-deployment.yml
@@ -105,3 +105,9 @@ jobs:
           LOCAL_PATH: ${{ inputs.LOCAL_PATH }}
           CACHE_CONTROL: ${{ inputs.CACHE_CONTROL }}
           EXTRA_ARGS: ${{ inputs.EXTRA_ARGS }}
+
+      - name: Backport to staging
+        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        uses: aligent/workflows/.github/actions/backport@main
+        with:
+          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}

--- a/.github/workflows/static-hosting-deployment.yml
+++ b/.github/workflows/static-hosting-deployment.yml
@@ -50,6 +50,18 @@ on:
         type: string
         required: false
 
+      # Backport Configuration
+      create-backport-pr:
+        description: "Create a backport PR to staging after deployment"
+        type: boolean
+        required: false
+        default: false
+      backport-target-branch:
+        description: "Target branch for backport PR"
+        type: string
+        required: false
+        default: "staging"
+
 permissions: {}
 
 jobs:
@@ -107,7 +119,7 @@ jobs:
           EXTRA_ARGS: ${{ inputs.EXTRA_ARGS }}
 
       - name: Backport to staging
-        if: success() && vars.BACKPORT_TO_STAGING == 'true'
+        if: success() && inputs.create-backport-pr
         uses: aligent/workflows/.github/actions/backport@main
         with:
-          target-branch: ${{ vars.BACKPORT_TARGET_BRANCH || 'staging' }}
+          target-branch: ${{ inputs.backport-target-branch }}

--- a/docs/aio-app-deployment.md
+++ b/docs/aio-app-deployment.md
@@ -11,6 +11,8 @@ Deploys an Adobe I/O App Builder application using `aio app deploy`. Supports bo
 | `app-directory` | ❌ | string | `.` | Working directory for the app, relative to the repo root. Use for NX monorepo subdirectory apps. |
 | `package-manager` | ❌ | string | `yarn` | Node package manager to use (`npm` or `yarn`) |
 | `debug` | ❌ | boolean | `false` | Enable verbose logging |
+| `create-backport-pr` | ❌ | boolean | `false` | Create a backport PR after deployment |
+| `backport-target-branch` | ❌ | string | `staging` | Target branch for backport PR |
 
 #### **Variables and Secrets**
 
@@ -47,13 +49,6 @@ Configure these in the GitHub Environment (or at the repository level if not usi
 | `AIO_DEPLOY_EXTRA_SECRETS` | Secret | Additional secret environment variables to inject into the deploy step |
 
 Both extra fields accept multiline `KEY=VALUE` pairs — one per line. Use these for app-specific runtime configuration that varies per project, such as third-party API credentials, AWS credentials, or feature flags.
-
-**Backport Configuration** — optional:
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
 
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 

--- a/docs/aio-app-deployment.md
+++ b/docs/aio-app-deployment.md
@@ -48,6 +48,15 @@ Configure these in the GitHub Environment (or at the repository level if not usi
 
 Both extra fields accept multiline `KEY=VALUE` pairs — one per line. Use these for app-specific runtime configuration that varies per project, such as third-party API credentials, AWS credentials, or feature flags.
 
+**Backport Configuration** — optional:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
+
 Example `AIO_DEPLOY_EXTRA_VARS` value:
 ```
 AWS_REGION=ap-southeast-2

--- a/docs/aio-mesh-deployment.md
+++ b/docs/aio-mesh-deployment.md
@@ -14,6 +14,8 @@ Creates or updates an Adobe I/O API Mesh. Automatically detects whether the mesh
 | `build-command` | ❌ | string | | Command to run before deploying (e.g. `yarn build:resolvers`). Required when the mesh uses custom resolvers that must be compiled first. |
 | `provisioning-timeout` | ❌ | number | `300` | Seconds to wait for provisioning before failing |
 | `debug` | ❌ | boolean | `false` | Enable verbose logging |
+| `create-backport-pr` | ❌ | boolean | `false` | Create a backport PR after deployment |
+| `backport-target-branch` | ❌ | string | `staging` | Target branch for backport PR |
 
 #### **Variables and Secrets**
 
@@ -46,13 +48,6 @@ Configure these in the GitHub Environment (or at the repository level if not usi
 | `AIO_MESH_SECRETS` | Secret | Secrets to inject into the mesh via `secrets.yaml` (passed as `--secrets=secrets.yaml`) |
 
 Both fields accept multiline `KEY=VALUE` pairs — one per line. If neither is set, the `--env` and `--secrets` flags are omitted from the mesh command.
-
-**Backport Configuration** — optional:
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
 
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 

--- a/docs/aio-mesh-deployment.md
+++ b/docs/aio-mesh-deployment.md
@@ -47,6 +47,15 @@ Configure these in the GitHub Environment (or at the repository level if not usi
 
 Both fields accept multiline `KEY=VALUE` pairs — one per line. If neither is set, the `--env` and `--secrets` flags are omitted from the mesh command.
 
+**Backport Configuration** — optional:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
+
 Example `AIO_MESH_ENV_VARS` value:
 ```
 BACKEND_ENDPOINT=https://api.example.com

--- a/docs/gadget-deploy.md
+++ b/docs/gadget-deploy.md
@@ -22,6 +22,9 @@ A comprehensive Gadget app deployment workflow supporting push, test, and produc
 | push-staging | ❌ | boolean | false | Enable production deployment |
 | test | ❌ | boolean | false | Enable testing on development environment |
 | deploy-production | ❌ | boolean | false | Enable production deployment |
+| **Backport Configuration** |
+| create-backport-pr | ❌ | boolean | false | Create a backport PR after deployment |
+| backport-target-branch | ❌ | string | staging | Target branch for backport PR |
 
 #### **Secrets**
 | Name | Required | Description |
@@ -33,15 +36,6 @@ A comprehensive Gadget app deployment workflow supporting push, test, and produc
 | Name | Description |
 |------|-------------|
 | push-environment-status | Status of test environment push (success/failure) |
-
-#### **Backport Configuration (Optional)**
-
-Enable automatic PR creation to backport changes to a staging branch after successful deployments.
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
 
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 

--- a/docs/gadget-deploy.md
+++ b/docs/gadget-deploy.md
@@ -9,6 +9,7 @@ A comprehensive Gadget app deployment workflow supporting push, test, and produc
 - **Force push capabilities**: Ensures code synchronization with `--force` flag
 - **Gadget CLI integration**: Uses `ggt` CLI tool for all operations
 - **Test validation**: Runs full test suite before production deployment
+- **Automatic backporting**: Optional PR creation to backport changes to staging branch
 
 #### **Inputs**
 | Name | Required | Type | Default | Description |
@@ -32,6 +33,17 @@ A comprehensive Gadget app deployment workflow supporting push, test, and produc
 | Name | Description |
 |------|-------------|
 | push-environment-status | Status of test environment push (success/failure) |
+
+#### **Backport Configuration (Optional)**
+
+Enable automatic PR creation to backport changes to a staging branch after successful deployments.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 
 #### **Example Usage**
 

--- a/docs/magento-cloud-deploy.md
+++ b/docs/magento-cloud-deploy.md
@@ -9,6 +9,7 @@ A simple Magento Cloud deployment workflow that pushes code to your Magento Clou
 - **CST system integration**: Optional composer.lock reporting to Confidentiality and Security Team
 - **Environment protection**: Uses GitHub environment protection rules for deployment gates
 - **Full git history support**: Required for Magento Cloud deployment requirements
+- **Automatic backporting**: Optional PR creation to backport changes to staging branch
 
 #### **Inputs**
 | Name | Required | Type | Default | Description |
@@ -37,6 +38,17 @@ A simple Magento Cloud deployment workflow that pushes code to your Magento Clou
 |------|-------------|
 | CST_ENDPOINT | CST endpoint base URL (e.g., `https://package.report.aligent.consulting`) |
 | CST_PROJECT_KEY | CST project identifier for your organization |
+
+#### **Backport Configuration (Optional)**
+
+Enable automatic PR creation to backport changes to a staging branch after successful deployments.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 
 #### **Outputs**
 | Name | Description |

--- a/docs/magento-cloud-deploy.md
+++ b/docs/magento-cloud-deploy.md
@@ -25,6 +25,9 @@ A simple Magento Cloud deployment workflow that pushes code to your Magento Clou
 | cst-branch | ❌ | string | | CST branch to report against (optional, defaults to repository default branch) |
 | **Advanced Configuration** |
 | debug | ❌ | boolean | false | Enable verbose logging and debug output |
+| **Backport Configuration** |
+| create-backport-pr | ❌ | boolean | false | Create a backport PR after deployment |
+| backport-target-branch | ❌ | string | staging | Target branch for backport PR |
 
 #### **Secrets**
 | Name | Required | Description |
@@ -38,15 +41,6 @@ A simple Magento Cloud deployment workflow that pushes code to your Magento Clou
 |------|-------------|
 | CST_ENDPOINT | CST endpoint base URL (e.g., `https://package.report.aligent.consulting`) |
 | CST_PROJECT_KEY | CST project identifier for your organization |
-
-#### **Backport Configuration (Optional)**
-
-Enable automatic PR creation to backport changes to a staging branch after successful deployments.
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
 
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 

--- a/docs/nx-serverless-deployment.md
+++ b/docs/nx-serverless-deployment.md
@@ -8,6 +8,8 @@
 | package-manager      | ❌       | string  | yarn            | Node package manager to use                |
 | build-command        | ❌       | string  | build           | Command to override the build command      |
 | debug                | ❌       | boolean | false           | If verbose logging should be enabled       |
+| create-backport-pr   | ❌       | boolean | false           | Create a backport PR after deployment      |
+| backport-target-branch | ❌     | string  | staging         | Target branch for backport PR              |
 
 #### **Variables and Secrets**
 
@@ -20,13 +22,6 @@ These should be configured in your GitHub Environment (or at the repository leve
 | `AWS_SECRET_ACCESS_KEY` | ✅ | Secret | AWS Secret Access Key for authentication |
 | `CFN_ROLE` | ✅ | Secret | CloudFormation role ARN to assume |
 | `AWS_REGION` | ❌ | Variable | AWS Region to deploy to (defaults to ap-southeast-2) |
-
-**Backport Configuration** — optional:
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
 
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 

--- a/docs/nx-serverless-deployment.md
+++ b/docs/nx-serverless-deployment.md
@@ -21,6 +21,14 @@ These should be configured in your GitHub Environment (or at the repository leve
 | `CFN_ROLE` | ✅ | Secret | CloudFormation role ARN to assume |
 | `AWS_REGION` | ❌ | Variable | AWS Region to deploy to (defaults to ap-southeast-2) |
 
+**Backport Configuration** — optional:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 
 **Note:** If calling this workflow from an external GitHub organisation, you will need to pass the AWS_SECRET_ACCESS_KEY explicitly (see example below).
 

--- a/docs/pwa-deployment.md
+++ b/docs/pwa-deployment.md
@@ -30,15 +30,6 @@ Environment-specific values are read directly from the GitHub Environment (set v
 
 Either `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` **or** `AWS_ROLE_ARN` must be configured. The workflow detects which to use automatically.
 
-#### **Backport Configuration (Optional)**
-
-Enable automatic PR creation to backport changes to a staging branch after successful deployments.
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | variable | Target branch for backport (defaults to `staging`) |
-
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 
 #### **Inputs**
@@ -66,6 +57,9 @@ Enable automatic PR creation to backport changes to a staging branch after succe
 | extra-sync-args | :x: | string | | Additional AWS S3 sync arguments |
 | **Debug and Control** |
 | debug | :x: | boolean | false | Enable verbose logging and debug output |
+| **Backport Configuration** |
+| create-backport-pr | :x: | boolean | false | Create a backport PR after deployment |
+| backport-target-branch | :x: | string | staging | Target branch for backport PR |
 
 #### **Outputs**
 | Name | Description |

--- a/docs/pwa-deployment.md
+++ b/docs/pwa-deployment.md
@@ -11,6 +11,7 @@ A comprehensive Progressive Web Application deployment workflow supporting S3 st
 - **Node.js 16-22 support**: Compatible with Yarn and npm package managers
 - **Manual production gates**: Environment-based deployment protection
 - **Comprehensive caching**: Build artifact optimisation and cleanup
+- **Automatic backporting**: Optional PR creation to backport changes to staging branch
 
 #### **GitHub Environment Variables and Secrets**
 
@@ -28,6 +29,17 @@ Environment-specific values are read directly from the GitHub Environment (set v
 | `AWS_ROLE_ARN` | variable | :white_check_mark: | IAM role ARN to assume via OIDC (alternative to static credentials) |
 
 Either `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` **or** `AWS_ROLE_ARN` must be configured. The workflow detects which to use automatically.
+
+#### **Backport Configuration (Optional)**
+
+Enable automatic PR creation to backport changes to a staging branch after successful deployments.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 
 #### **Inputs**
 | Name | Required | Type | Default | Description |

--- a/docs/s3-deploy.md
+++ b/docs/s3-deploy.md
@@ -17,6 +17,17 @@
 |--------------------- |----------|--------------------------------------------|
 | aws-secret-access-key| ✅       | AWS Secret Access Key                      |
 
+#### **Backport Configuration (Optional)**
+
+Enable automatic PR creation to backport changes to a staging branch after successful deployments.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
+
 #### Example Usage
 
 ```yaml

--- a/docs/s3-deploy.md
+++ b/docs/s3-deploy.md
@@ -11,20 +11,13 @@
 | cache-control        | ❌       | string  |                 | Cache control headers                      |
 | extra-args           | ❌       | string  |                 | Additional AWS CLI args                    |
 | aws-access-key-id    | ✅       | string  |                 | AWS Access Key ID                          |
+| create-backport-pr   | ❌       | boolean | false           | Create a backport PR after deployment      |
+| backport-target-branch | ❌     | string  | staging         | Target branch for backport PR              |
 
 #### **Secrets**
 | Name                  | Required | Description                               |
 |--------------------- |----------|--------------------------------------------|
 | aws-secret-access-key| ✅       | AWS Secret Access Key                      |
-
-#### **Backport Configuration (Optional)**
-
-Enable automatic PR creation to backport changes to a staging branch after successful deployments.
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
 
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 

--- a/docs/shopify-deploy.md
+++ b/docs/shopify-deploy.md
@@ -20,20 +20,14 @@ A reusable workflow for deploying Shopify apps using the Shopify CLI with suppor
 | **Deployment Control** |
 | deploy-staging | ❌ | boolean | false | Enable staging deployment |
 | deploy-production | ❌ | boolean | false | Enable production deployment |
+| **Backport Configuration** |
+| create-backport-pr | ❌ | boolean | false | Create a backport PR after deployment |
+| backport-target-branch | ❌ | string | staging | Target branch for backport PR |
 
 #### **Secrets**
 | Name | Required | Description |
 |------|----------|-------------|
 | shopify_cli_token | ✅ | Shopify CLI authentication token |
-
-#### **Backport Configuration (Optional)**
-
-Enable automatic PR creation to backport changes to a staging branch after successful deployments.
-
-| Name | Type | Description |
-|------|------|-------------|
-| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
-| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
 
 **Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 

--- a/docs/shopify-deploy.md
+++ b/docs/shopify-deploy.md
@@ -8,6 +8,7 @@ A reusable workflow for deploying Shopify apps using the Shopify CLI with suppor
 - **Build artifact integration**: Downloads pre-built artifacts before deployment
 - **Shopify CLI integration**: Uses Shopify CLI for configuration and deployment
 - **Deployment validation**: Ensures at least one deployment target is selected
+- **Automatic backporting**: Optional PR creation to backport changes to staging branch
 
 #### **Inputs**
 | Name | Required | Type | Default | Description |
@@ -24,6 +25,17 @@ A reusable workflow for deploying Shopify apps using the Shopify CLI with suppor
 | Name | Required | Description |
 |------|----------|-------------|
 | shopify_cli_token | ✅ | Shopify CLI authentication token |
+
+#### **Backport Configuration (Optional)**
+
+Enable automatic PR creation to backport changes to a staging branch after successful deployments.
+
+| Name | Type | Description |
+|------|------|-------------|
+| `BACKPORT_TO_STAGING` | Variable | Set to `true` to enable backporting |
+| `BACKPORT_TARGET_BRANCH` | Variable | Target branch for backport (defaults to `staging`) |
+
+**Note:** Backporting only occurs when deploying from `production`, `main`, or `master` branches. Deployments from other branches are skipped.
 
 #### **Prerequisites**
 - A `.nvmrc` file in the repository root specifying the Node.js version


### PR DESCRIPTION
Add backport action that creates PRs to backport changes from production-like branches (production, main, master) to staging after successful deployments.

Changes:
- Add .github/actions/backport/action.yml with source branch validation
- Integrate backport step into all 9 deployment workflows
- Update documentation for all affected workflows

Configuration:
- BACKPORT_TO_STAGING=true to enable (repo or environment variable)
- BACKPORT_TARGET_BRANCH to customize target (defaults to staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Description of the proposed changes**

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

