### PR TITLE
fix GSM-29: prevent duplicate theme deploys for the same PR

### DIFF
--- a/.github/workflows/shopify-theme-pr.yml
+++ b/.github/workflows/shopify-theme-pr.yml
@@ -136,14 +136,27 @@ jobs:
       - name: Install Shopify CLI
         run: npm install -g @shopify/cli@latest
 
-      - name: Push unpublished theme
+      - name: Push theme
         working-directory: ${{ inputs.working-directory }}
         run: |
-          shopify theme push \
-            --unpublished \
-            --json \
-            --theme "$PR_THEME_NAME" \
-            > push.json
+          # Check if a theme with this name already exists
+          EXISTING_ID=$(shopify theme list --json \
+            | jq -r --arg name "$PR_THEME_NAME" '.[] | select(.name == $name) | .id // empty')
+
+          if [ -n "$EXISTING_ID" ]; then
+            echo "Updating existing preview theme (ID: $EXISTING_ID)"
+            shopify theme push \
+              --json \
+              --theme "$EXISTING_ID" \
+              > push.json
+          else
+            echo "Creating new preview theme"
+            shopify theme push \
+              --unpublished \
+              --json \
+              --theme "$PR_THEME_NAME" \
+              > push.json
+          fi
 
       - name: Extract preview URL
         id: preview


### PR DESCRIPTION
**Description of the proposed changes**

The previous logic would always deploy a new theme, rather than use an existing deployment. This change makes it so themes would only be published new if they don't already exist. Otherwise they'll use an existing theme deployment.

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

