### PR TITLE
Truncate CDK diff PR comment when over GitHub's comment-length limit

### DIFF
--- a/.github/workflows/aws-cdk.yml
+++ b/.github/workflows/aws-cdk.yml
@@ -613,31 +613,52 @@ jobs:
             const statusIcon = hasChanges ? '⚠️' : '✅';
             const statusText = hasChanges ? 'Infrastructure changes detected' : 'No infrastructure changes detected';
 
-            const lines = [
-              `## ${commentHeader}`,
-              '',
-              `${statusIcon} **${statusText}**`,
-              '',
-              `**Stack:** \`${stackName}\``,
-            ];
+            const GITHUB_COMMENT_LIMIT = 65536;
+            const SAFE_LIMIT = 60000;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
 
-            if (environment) {
-              lines.push(`**Environment:** ${environment}`);
+            function buildBody(diff, truncationNotice) {
+              const lines = [
+                `## ${commentHeader}`,
+                '',
+                `${statusIcon} **${statusText}**`,
+                '',
+                `**Stack:** \`${stackName}\``,
+              ];
+
+              if (environment) {
+                lines.push(`**Environment:** ${environment}`);
+              }
+
+              if (truncationNotice) {
+                lines.push('', truncationNotice);
+              }
+
+              lines.push(
+                '',
+                '<details>',
+                `<summary>Full diff${truncationNotice ? ' (truncated)' : ''}</summary>`,
+                '',
+                '```',
+                diff,
+                '```',
+                '',
+                '</details>'
+              );
+
+              return lines.join('\n');
             }
 
-            lines.push(
-              '',
-              '<details>',
-              '<summary>Full diff</summary>',
-              '',
-              '```',
-              diffContent,
-              '```',
-              '',
-              '</details>'
-            );
+            let commentBody = buildBody(diffContent, null);
 
-            const commentBody = lines.join('\n');
+            if (commentBody.length > SAFE_LIMIT) {
+              const originalLength = commentBody.length;
+              const truncationNotice = `**Note:** Diff output exceeded GitHub's ${GITHUB_COMMENT_LIMIT}-character comment limit (${originalLength} chars). Download the full diff from the [workflow run artifacts](${runUrl}).`;
+              const overhead = buildBody('', truncationNotice).length;
+              const availableForDiff = Math.max(0, SAFE_LIMIT - overhead - 20);
+              const truncatedDiff = diffContent.slice(0, availableForDiff) + '\n...[truncated]';
+              commentBody = buildBody(truncatedDiff, truncationNotice);
+            }
 
             const comments = await github.rest.issues.listComments({
               owner, repo, issue_number,

--- a/.github/workflows/aws-cdk.yml
+++ b/.github/workflows/aws-cdk.yml
@@ -653,7 +653,11 @@ jobs:
 
             if (commentBody.length > SAFE_LIMIT) {
               const originalLength = commentBody.length;
-              const truncationNotice = `**Note:** Diff output exceeded GitHub's ${GITHUB_COMMENT_LIMIT}-character comment limit (${originalLength} chars). Download the full diff from the [workflow run artifacts](${runUrl}).`;
+              const truncationNotice = [
+                `**Note:** Diff output exceeded GitHub's ${GITHUB_COMMENT_LIMIT}-character`,
+                `comment limit (${originalLength} chars).`,
+                `Download the full diff from the [workflow run artifacts](${runUrl}).`,
+              ].join(' ');
               const overhead = buildBody('', truncationNotice).length;
               const availableForDiff = Math.max(0, SAFE_LIMIT - overhead - 20);
               const truncatedDiff = diffContent.slice(0, availableForDiff) + '\n...[truncated]';


### PR DESCRIPTION
## Summary
- When a CDK diff is very large (e.g. broad IAM pipeline changes that cascade across many stacks), the generated PR comment body exceeds GitHub's 65,536 character issue comment limit.
- The `Post diff to PR comment` step then fails with `Body is too long (maximum is 65536 characters)`, marking the whole CDK job red even though the diff was produced successfully.
- Fix: when the body exceeds a safe limit (60,000 chars) the inline diff is truncated and a notice linking to the workflow run artifacts is included. The full diff is already uploaded as `deployment-diff-<stack>` by the prior step, so no information is lost.

## Context
- Triggered by `aligent/aligent-aws-access-cdk` PR #49 (deleting the trucktech stack). Removing one client shifts every `client-account-deploys.N` pipeline index, producing a diff comment roughly 289,000 characters long.
- Failing run: https://github.com/aligent/aligent-aws-access-cdk/actions/runs/24649758423

<img width="1660" height="1355" alt="image" src="https://github.com/user-attachments/assets/ab7070b7-d75b-43e4-9294-782c7e1b189c" />


