### PR TITLE
HOTFIX: Add build env 

### DIFF
--- a/.github/workflows/pwa-deployment.yml
+++ b/.github/workflows/pwa-deployment.yml
@@ -40,6 +40,11 @@ on:
         type: boolean
         required: false
         default: false
+      build-env:
+        description: "BUILD_ENV value (falls back to vars.BUILD_ENV if not provided)"
+        type: string
+        required: false
+        default: ""
       build-command:
         description: "Build command to execute"
         type: string
@@ -348,6 +353,7 @@ jobs:
           INPUTS_PACKAGE_MANAGER: ${{ inputs.package-manager }}
           INPUTS_DEBUG: ${{ inputs.debug }}
           INPUTS_IS_YARN_CLASSIC: ${{ inputs.is-yarn-classic }}
+          BUILD_ENV: ${{ inputs.build-env || vars.BUILD_ENV }}
 
       - name: Build application
         run: |
@@ -369,6 +375,7 @@ jobs:
           INPUTS_PACKAGE_MANAGER: ${{ inputs.package-manager }}
           INPUTS_BUILD_COMMAND: ${{ inputs.build-command }}
           INPUTS_DEBUG: ${{ inputs.debug }}
+          BUILD_ENV: ${{ inputs.build-env || vars.BUILD_ENV }}
 
       - name: Verify build output
         run: |


### PR DESCRIPTION
**Description of the proposed changes**
Adding in a build-env input as well as a fallback to vars.BUILD_ENV as some projects (OTR) use it to determine which .env file to use during their build process.

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

