### PR TITLE
PJH-146: Use SHOPIFY_CLI_PARTNERS_TOKEN for Shopify deploy

### DIFF
--- a/.github/workflows/shopify-deploy.yml
+++ b/.github/workflows/shopify-deploy.yml
@@ -25,7 +25,7 @@ on:
 
     secrets:
       shopify_cli_token:
-        description: 'Shopify CLI authentication token'
+        description: 'Shopify CLI partner authentication token'
         required: true
 
 jobs:
@@ -64,7 +64,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         run: yarn shopify app deploy --allow-updates
         env:
-          SHOPIFY_CLI_TOKEN: ${{ secrets.shopify_cli_token }}
+          SHOPIFY_CLI_PARTNERS_TOKEN: ${{ secrets.shopify_cli_token }}
           SHOPIFY_FLAG_PATH: ${{ inputs.working-directory }}
 
       - name: Backport to staging


### PR DESCRIPTION
## Summary
- Updates the Shopify deploy workflow to use `SHOPIFY_CLI_PARTNERS_TOKEN` instead of `SHOPIFY_CLI_TOKEN` as the environment variable for authentication
- Updates the secret description to clarify it is a partner authentication token

For more information around this change: https://shopify.dev/docs/apps/launch/deployment/deploy-in-ci-cd-pipeline#step-3-integrate-shopify-cli-into-your-pipeline