### PR TITLE
HOTFIX: Set fetch-depth to 0 for the phpstan check

### DIFF
--- a/.github/workflows/php-quality-checks.yml
+++ b/.github/workflows/php-quality-checks.yml
@@ -357,6 +357,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f #2.37.0


### PR DESCRIPTION
**Description of the proposed changes**
Currently the phpstan check is failing silently as it cannot get a diff of what files have changed. This along with an updated script in the repo should allow phpstan to start working again in github.

```bash
#!/bin/bash

# Detect environment and get changed PHP files accordingly
if [ "${GITHUB_ACTIONS}" = "true" ]; then
    # CI: diff against PR base branch
    BASE_REF="${GITHUB_BASE_REF:-production}"
    git fetch origin "$BASE_REF" --depth=1
    PHP_FILES=$(git diff --name-only --diff-filter=AM "origin/${BASE_REF}...HEAD" -- '*.php' '*.phtml')
else
    # Local pre-commit hook (cghooks): diff against staged index
    PHP_FILES=$(git diff --name-only --cached --diff-filter=AM -- '*.php' '*.phtml')
fi

if [[ -z "$PHP_FILES" ]]; then
    echo "Nothing to analyse"
else
    ./vendor/bin/phpstan analyse -c php.neon $PHP_FILES
fi
```

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

