### PR TITLE
HOTFIX: Move corepack enable before setup node

### DIFF
--- a/.github/workflows/aio-app-deployment.yml
+++ b/.github/workflows/aio-app-deployment.yml
@@ -86,15 +86,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Enable Corepack
+        if: inputs.package-manager == 'yarn'
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version-file: .nvmrc
           cache: ${{ inputs.package-manager }}
-
-      - name: Enable Corepack
-        if: inputs.package-manager == 'yarn'
-        run: corepack enable
 
       - name: Install dependencies (npm)
         if: inputs.package-manager != 'yarn'

--- a/.github/workflows/aio-mesh-deployment.yml
+++ b/.github/workflows/aio-mesh-deployment.yml
@@ -95,15 +95,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Enable Corepack
+        if: inputs.package-manager == 'yarn'
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version-file: .nvmrc
           cache: ${{ inputs.package-manager }}
-
-      - name: Enable Corepack
-        if: inputs.package-manager == 'yarn'
-        run: corepack enable
 
       - name: Install dependencies (npm)
         if: inputs.package-manager != 'yarn'


### PR DESCRIPTION
**Description of the proposed changes**
The adobe mesh deploy is failing as it is trying to setup the yarn cache during the setup-node action and failing as corepack has not been enabled yet. 

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

