### PR TITLE
HOTFIX: Disable glob expansion 

### DIFF
--- a/.github/workflows/pwa-deployment.yml
+++ b/.github/workflows/pwa-deployment.yml
@@ -467,6 +467,9 @@ jobs:
         run: |
           echo "🔄 Invalidating CloudFront cache..."
 
+          # Disable glob expansion so /* is never expanded to filesystem paths
+          set -f
+
           # Parse invalidation paths
           PATHS=$(echo "${NEEDS_PREPARE_OUTPUTS_INVALIDATION_PATHS}" | jq -r '.[]')
 
@@ -490,6 +493,7 @@ jobs:
             --paths $PATHS \
             --query 'Invalidation.Id' \
             --output text)
+          set +f
 
           echo "✅ CloudFront invalidation created: $INVALIDATION_ID"
 


### PR DESCRIPTION
**Description of the proposed changes**
Disable glob expansion for the AWS invalidate command so we don't expand out to the linux root directory paths. 

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

