### PR TITLE
Fix Publish Release Info step failing to parse published packages

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -172,7 +172,7 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           echo "Published packages:"
-          echo '${STEPS_CHANGESETS_OUTPUTS_PUBLISHEDPACKAGES}' | jq -r '.[] | "- \(.name)@\(.version)"'
+          echo "${STEPS_CHANGESETS_OUTPUTS_PUBLISHEDPACKAGES}" | jq -r '.[] | "- \(.name)@\(.version)"'
         env:
           STEPS_CHANGESETS_OUTPUTS_PUBLISHEDPACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
 


### PR DESCRIPTION
## What

The `Publish Release Info` step in `changeset-release.yml` was failing with:

```
jq: parse error: Invalid numeric literal at line 1, column 2
Process completed with exit code 5
```

This failed the whole release job for consumers (for example take-flight) even though the packages had already been published to npm and the tags had been pushed. It only passed on a re-run because there were no longer any unpublished packages, so the step was skipped.

The step passes the published packages JSON through the `STEPS_CHANGESETS_OUTPUTS_PUBLISHEDPACKAGES` env var (added during the earlier zizmor template injection hardening), but the variable was referenced inside single quotes:

```bash
echo '${STEPS_CHANGESETS_OUTPUTS_PUBLISHEDPACKAGES}' | jq -r '.[] | "- \(.name)@\(.version)"'
```

Single quotes stop the shell from expanding the variable, so `jq` received the literal string `${STEPS_CHANGESETS_OUTPUTS_PUBLISHEDPACKAGES}` rather than the JSON array, and bailed out. The sibling `post-publish-commands` step in the same file already uses double quotes correctly, so this was just an oversight when the env var was introduced.

### Fix

Use double quotes so the shell expands the env var, while still keeping the value out of the inline script:

```bash
echo "${STEPS_CHANGESETS_OUTPUTS_PUBLISHEDPACKAGES}" | jq -r '.[] | "- \(.name)@\(.version)"'
```

### Testing

Reproduced locally with the same input and confirmed the behaviour:

```
# before (single quotes): jq parse error, exit 5
# after  (double quotes): prints "- a@1.0.0", exit 0
```