### PR TITLE
Trim carriage return \r in parsed multi-line env vars and secrets

### DIFF
--- a/.github/workflows/aio-app-deployment.yml
+++ b/.github/workflows/aio-app-deployment.yml
@@ -129,12 +129,12 @@ jobs:
         run: |
           if [ -n "$EXTRA_VARS" ]; then
             while IFS= read -r line; do
-              [ -n "$line" ] && echo "$line" >> "$GITHUB_ENV"
+              [ -n "$line" ] && echo "$line" | tr -d '\r' >> "$GITHUB_ENV"
             done <<< "$EXTRA_VARS"
           fi
           if [ -n "$EXTRA_SECRETS" ]; then
             while IFS= read -r line; do
-              [ -n "$line" ] && echo "$line" >> "$GITHUB_ENV"
+              [ -n "$line" ] && echo "$line" | tr -d '\r' >> "$GITHUB_ENV"
             done <<< "$EXTRA_SECRETS"
           fi
 


### PR DESCRIPTION
**Description of the proposed changes**
Strip `\r` carriage return characters when exporting `AIO_DEPLOY_EXTRA_VARS` and `AIO_DEPLOY_EXTRA_SECRETS` to `$GITHUB_ENV`.

Multi-line GitHub variables (`vars.*` / `secrets.*`) can contain Windows-style line endings (`\r\n`). When these are parsed and appended to `$GITHUB_ENV`, the trailing `\r` becomes part of the value (e.g. `MY_VAR=some_value\r`), causing silent failures in downstream steps that consume these environment variables.

https://aligent.slack.com/archives/C093KUAK6BV/p1780440624446019?thread_ts=1780281479.709199&cid=C093KUAK6BV

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

