### PR TITLE
DO-1743: Add EXTRA_VARS and EXTRA_SECRETS

### DIFF
--- a/.github/workflows/aws-cdk.yml
+++ b/.github/workflows/aws-cdk.yml
@@ -226,6 +226,22 @@ jobs:
               ;;
           esac
 
+      - name: Export extra environment variables
+        env:
+          EXTRA_VARS: ${{ vars.EXTRA_VARS }}
+          EXTRA_SECRETS: ${{ secrets.EXTRA_SECRETS }}
+        run: |
+          if [ -n "$EXTRA_VARS" ]; then
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "$line" | tr -d '\r' >> "$GITHUB_ENV"
+            done <<< "$EXTRA_VARS"
+          fi
+          if [ -n "$EXTRA_SECRETS" ]; then
+            while IFS= read -r line; do
+              [ -n "$line" ] && echo "$line" | tr -d '\r' >> "$GITHUB_ENV"
+            done <<< "$EXTRA_SECRETS"
+          fi
+
       - name: Set CDK commands
         id: parse-cdk-config
         env:

--- a/docs/aws-cdk.md
+++ b/docs/aws-cdk.md
@@ -55,6 +55,12 @@ These should be configured in your GitHub Environment (or at the repository leve
 
 > **Authentication:** Configure either static credentials (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`) **or** OIDC (`AWS_ROLE_ARN`). The workflow auto-detects which method to use.
 
+**Extras** — optional:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `EXTRA_VARS` | Variable | Additional non-secret environment variables to inject into the deploy step |
+| `EXTRA_SECRETS` | Secret | Additional secret environment variables to inject into the deploy step |
 
 #### **Outputs**
 | Name | Description |

--- a/docs/aws-cdk.md
+++ b/docs/aws-cdk.md
@@ -62,6 +62,8 @@ These should be configured in your GitHub Environment (or at the repository leve
 | `EXTRA_VARS` | Variable | Additional non-secret environment variables to inject into the deploy step |
 | `EXTRA_SECRETS` | Secret | Additional secret environment variables to inject into the deploy step |
 
+Both extra fields accept multiline `KEY=VALUE` pairs — one per line. Use these for runtime configuration that varies per project, such as feature flags.
+
 #### **Outputs**
 | Name | Description |
 |------|-------------|


### PR DESCRIPTION
**Description of the proposed changes**
When migrating https://github.com/aligent/dns-redirect-service I found that it requires arbitrary env vars e.g. DOMAINS that are then used at synth / deploy time. This PR adds in a step that pulls the EXTRA_VARS and EXTRA_SECRETS (if they exist) into the GITHUB_ENV so they are available for synth. 

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

**Time Tracking**

ABC-xxx: code review, select project XXXX