### PR TITLE
DO-2039: Add opensearch-plugins input to php-quality-checks

### DIFF
--- a/.github/workflows/php-quality-checks.yml
+++ b/.github/workflows/php-quality-checks.yml
@@ -146,6 +146,14 @@ on:
         required: false
         default: "opensearchproject/opensearch"
 
+      opensearch-plugins:
+        description: >-
+          Space-separated OpenSearch plugins to install into the search service
+          before tests run (e.g., "analysis-icu analysis-phonetic")
+        type: string
+        required: false
+        default: ""
+
 jobs:
   # Install Composer dependencies with caching and detect available tools
   install:
@@ -804,6 +812,19 @@ jobs:
             [ -d "pub" ] && echo "  ✅ pub/"
           fi
 
+      - name: Install OpenSearch plugins
+        if: inputs.opensearch-plugins != ''
+        run: |
+          echo "🔌 Installing OpenSearch plugins: ${{ inputs.opensearch-plugins }}"
+          for plugin in ${{ inputs.opensearch-plugins }}; do
+            docker exec ${{ job.services.search.id }} \
+              bin/opensearch-plugin install --batch "$plugin"
+          done
+          docker restart ${{ job.services.search.id }}
+          echo "⏳ Waiting for OpenSearch to restart..."
+          timeout 120 bash -c 'until curl -sf http://localhost:9200/_cluster/health; do sleep 3; done'
+          echo "✅ OpenSearch is up with plugins installed"
+
       - name: Run Integration Tests
         run: |
           echo "🔗 Running integration tests..."
@@ -930,6 +951,19 @@ jobs:
             [ -d "setup" ] && echo "  ✅ setup/"
             [ -d "pub" ] && echo "  ✅ pub/"
           fi
+
+      - name: Install OpenSearch plugins
+        if: inputs.opensearch-plugins != ''
+        run: |
+          echo "🔌 Installing OpenSearch plugins: ${{ inputs.opensearch-plugins }}"
+          for plugin in ${{ inputs.opensearch-plugins }}; do
+            docker exec ${{ job.services.search.id }} \
+              bin/opensearch-plugin install --batch "$plugin"
+          done
+          docker restart ${{ job.services.search.id }}
+          echo "⏳ Waiting for OpenSearch to restart..."
+          timeout 120 bash -c 'until curl -sf http://localhost:9200/_cluster/health; do sleep 3; done'
+          echo "✅ OpenSearch is up with plugins installed"
 
       - name: Run REST API Tests
         run: |
@@ -1078,6 +1112,19 @@ jobs:
             [ -d "setup" ] && echo "  ✅ setup/"
             [ -d "pub" ] && echo "  ✅ pub/"
           fi
+
+      - name: Install OpenSearch plugins
+        if: inputs.opensearch-plugins != ''
+        run: |
+          echo "🔌 Installing OpenSearch plugins: ${{ inputs.opensearch-plugins }}"
+          for plugin in ${{ inputs.opensearch-plugins }}; do
+            docker exec ${{ job.services.search.id }} \
+              bin/opensearch-plugin install --batch "$plugin"
+          done
+          docker restart ${{ job.services.search.id }}
+          echo "⏳ Waiting for OpenSearch to restart..."
+          timeout 120 bash -c 'until curl -sf http://localhost:9200/_cluster/health; do sleep 3; done'
+          echo "✅ OpenSearch is up with plugins installed"
 
       - name: Run GraphQL API Tests
         run: |

--- a/.github/workflows/php-quality-checks.yml
+++ b/.github/workflows/php-quality-checks.yml
@@ -814,13 +814,16 @@ jobs:
 
       - name: Install OpenSearch plugins
         if: inputs.opensearch-plugins != ''
+        env:
+          OPENSEARCH_PLUGINS: ${{ inputs.opensearch-plugins }}
+          SEARCH_CONTAINER_ID: ${{ job.services.search.id }}
         run: |
-          echo "🔌 Installing OpenSearch plugins: ${{ inputs.opensearch-plugins }}"
-          for plugin in ${{ inputs.opensearch-plugins }}; do
-            docker exec ${{ job.services.search.id }} \
+          echo "🔌 Installing OpenSearch plugins: $OPENSEARCH_PLUGINS"
+          for plugin in $OPENSEARCH_PLUGINS; do
+            docker exec "$SEARCH_CONTAINER_ID" \
               bin/opensearch-plugin install --batch "$plugin"
           done
-          docker restart ${{ job.services.search.id }}
+          docker restart "$SEARCH_CONTAINER_ID"
           echo "⏳ Waiting for OpenSearch to restart..."
           timeout 120 bash -c 'until curl -sf http://localhost:9200/_cluster/health; do sleep 3; done'
           echo "✅ OpenSearch is up with plugins installed"
@@ -954,13 +957,16 @@ jobs:
 
       - name: Install OpenSearch plugins
         if: inputs.opensearch-plugins != ''
+        env:
+          OPENSEARCH_PLUGINS: ${{ inputs.opensearch-plugins }}
+          SEARCH_CONTAINER_ID: ${{ job.services.search.id }}
         run: |
-          echo "🔌 Installing OpenSearch plugins: ${{ inputs.opensearch-plugins }}"
-          for plugin in ${{ inputs.opensearch-plugins }}; do
-            docker exec ${{ job.services.search.id }} \
+          echo "🔌 Installing OpenSearch plugins: $OPENSEARCH_PLUGINS"
+          for plugin in $OPENSEARCH_PLUGINS; do
+            docker exec "$SEARCH_CONTAINER_ID" \
               bin/opensearch-plugin install --batch "$plugin"
           done
-          docker restart ${{ job.services.search.id }}
+          docker restart "$SEARCH_CONTAINER_ID"
           echo "⏳ Waiting for OpenSearch to restart..."
           timeout 120 bash -c 'until curl -sf http://localhost:9200/_cluster/health; do sleep 3; done'
           echo "✅ OpenSearch is up with plugins installed"
@@ -1115,13 +1121,16 @@ jobs:
 
       - name: Install OpenSearch plugins
         if: inputs.opensearch-plugins != ''
+        env:
+          OPENSEARCH_PLUGINS: ${{ inputs.opensearch-plugins }}
+          SEARCH_CONTAINER_ID: ${{ job.services.search.id }}
         run: |
-          echo "🔌 Installing OpenSearch plugins: ${{ inputs.opensearch-plugins }}"
-          for plugin in ${{ inputs.opensearch-plugins }}; do
-            docker exec ${{ job.services.search.id }} \
+          echo "🔌 Installing OpenSearch plugins: $OPENSEARCH_PLUGINS"
+          for plugin in $OPENSEARCH_PLUGINS; do
+            docker exec "$SEARCH_CONTAINER_ID" \
               bin/opensearch-plugin install --batch "$plugin"
           done
-          docker restart ${{ job.services.search.id }}
+          docker restart "$SEARCH_CONTAINER_ID"
           echo "⏳ Waiting for OpenSearch to restart..."
           timeout 120 bash -c 'until curl -sf http://localhost:9200/_cluster/health; do sleep 3; done'
           echo "✅ OpenSearch is up with plugins installed"

--- a/docs/php-quality-checks.md
+++ b/docs/php-quality-checks.md
@@ -36,6 +36,7 @@ A comprehensive PHP quality assurance workflow supporting static analysis, codin
 | rabbitmq-version | ❌ | string | 4.1-management | RabbitMQ Docker image tag. |
 | opensearch-image | ❌ | string | opensearchproject/opensearch | OpenSearch Docker image name, combined with `opensearch-version` as the tag. |
 | opensearch-version | ❌ | string | 2 | OpenSearch Docker image tag. |
+| opensearch-plugins | ❌ | string | "" | Space-separated OpenSearch plugins to install into the search service before tests run (e.g., `analysis-icu analysis-phonetic`). |
 | **Advanced Configuration** |
 | debug | ❌ | boolean | false | Enable verbose logging and debug output |
 
@@ -77,15 +78,15 @@ jobs:
       phpstan-level: "9"
 ```
 
-**Custom Service Images (e.g., OpenSearch with plugins):**
+**OpenSearch with plugins (e.g., Adobe Commerce):**
 ```yaml
 jobs:
   magento-quality:
     uses: aligent/workflows/.github/workflows/php-quality-checks.yml@main
     with:
       php-version: "8.4"
-      opensearch-image: "aligent/bitbucket-opensearch"
       opensearch-version: "3.1.0"
+      opensearch-plugins: "analysis-icu analysis-phonetic"
 ```
 
 **Magento project with pre-commit hook scripts (use-custom-config):**


### PR DESCRIPTION
GitHub service containers can't run commands before startup, so projects that need OpenSearch plugins had to point `opensearch-image` at a custom prebuilt image (e.g. `aligent/bitbucket-opensearch`, which is no longer publicly pullable and broke cooldrive-magento's PR checks).

This adds an optional `opensearch-plugins` input (space-separated, same style as `php-extensions`). When set, the integration/REST/GraphQL test jobs install the listed plugins into the search service container via `docker exec`, restart it, and wait for it to come back before running tests. `opensearch-plugin install` resolves the plugin build matching the running OpenSearch version, so it composes with `opensearch-version` without maintenance.

Default is empty, so existing consumers are unaffected.

Example:
```yaml
opensearch-version: "3.1.0"
opensearch-plugins: "analysis-icu analysis-phonetic"
```

First consumer: aligent/cooldrive-magento#106 / #107, which currently fail Magento's install with `Unknown filter type [phonetic]` on the stock OpenSearch image (Adobe Commerce needs analysis-icu + analysis-phonetic, matching its cloud services.yaml).